### PR TITLE
fix: Agregar LocationDTO para mejorar legibilidad de código.

### DIFF
--- a/src/aeroalpes/modulos/vuelos/aplicacion/dto.py
+++ b/src/aeroalpes/modulos/vuelos/aplicacion/dto.py
@@ -2,11 +2,16 @@ from dataclasses import dataclass, field
 from aeroalpes.seedwork.aplicacion.dto import DTO
 
 @dataclass(frozen=True)
+class LocationDTO(DTO):
+    codigo: str
+    nombre: str
+
+@dataclass(frozen=True)
 class LegDTO(DTO):
     fecha_salida: str
     fecha_llegada: str
-    origen: dict
-    destino: dict
+    origen: LocationDTO
+    destino: LocationDTO
 
 @dataclass(frozen=True)
 class SegmentoDTO(DTO):

--- a/src/aeroalpes/modulos/vuelos/aplicacion/mapeadores.py
+++ b/src/aeroalpes/modulos/vuelos/aplicacion/mapeadores.py
@@ -2,7 +2,7 @@ from aeroalpes.seedwork.aplicacion.dto import Mapeador as AppMap
 from aeroalpes.seedwork.dominio.repositorios import Mapeador as RepMap
 from aeroalpes.modulos.vuelos.dominio.entidades import Reserva, Aeropuerto
 from aeroalpes.modulos.vuelos.dominio.objetos_valor import Itinerario, Odo, Segmento, Leg
-from .dto import ReservaDTO, ItinerarioDTO, OdoDTO, SegmentoDTO, LegDTO
+from .dto import ReservaDTO, ItinerarioDTO, OdoDTO, SegmentoDTO, LegDTO, LocationDTO
 
 from datetime import datetime
 
@@ -15,7 +15,10 @@ class MapeadorReservaDTOJson(AppMap):
             for segmento in odo.get('segmentos', list()):
                 legs_dto: list[LegDTO] = list()
                 for leg in segmento.get('legs', list()):
-                    leg_dto: LegDTO = LegDTO(leg.get('fecha_salida'), leg.get('fecha_llegada'), leg.get('origen'), leg.get('destino')) 
+                    origen_location_dto = LocationDTO(leg.get('origen').get('codigo'), leg.get('origen').get('nombre'))
+                    destino_location_dto = LocationDTO(leg.get('destino').get('codigo'), leg.get('destino').get('nombre'))
+
+                    leg_dto: LegDTO = LegDTO(leg.get('fecha_salida'), leg.get('fecha_llegada'), origen_location_dto, destino_location_dto) 
                     legs_dto.append(leg_dto)  
                 
                 segmentos_dto.append(SegmentoDTO(legs_dto))
@@ -49,8 +52,8 @@ class MapeadorReserva(RepMap):
                 legs = list()
 
                 for leg_dto in seg_dto.legs:
-                    destino = Aeropuerto(codigo=leg_dto.destino.get('codigo'), nombre=leg_dto.destino.get('nombre'))
-                    origen = Aeropuerto(codigo=leg_dto.origen.get('codigo'), nombre=leg_dto.origen.get('nombre'))
+                    destino = Aeropuerto(codigo=leg_dto.destino.codigo, nombre=leg_dto.destino.nombre)
+                    origen = Aeropuerto(codigo=leg_dto.origen.codigo, nombre=leg_dto.origen.nombre)
                     fecha_salida = datetime.strptime(leg_dto.fecha_salida, self._FORMATO_FECHA)
                     fecha_llegada = datetime.strptime(leg_dto.fecha_llegada, self._FORMATO_FECHA)
 


### PR DESCRIPTION
## Describa el cambio
+ Se agrega LocationDTO para mejorar la legibilidad de los mapeadores en la capa de presentación.

## Razonamiento pedagógico
- Durante el mapeo de un objeto externo hacia un el DTO de reservas, se esta realizando un map de un diccionario. 
Esto trae consigo varias desventajas:
    - No es posible identificar en la capa presentación (primera capa), los atributos exactos y el tipo de dato necesario para dichos atributos, siendo necesario navegar hasta la capa aplicación (segunda capa) para poder identificarlos.
    - Acoplar el mapeador de Entidades al  json_request.

### Lista de chequeo
- [x] Ejecuté el proyecto de forma local o usando Gitpod
- [x] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas