### PR TITLE
fix: Se agrega nombre de destino y origen en consulta de reserva.

### DIFF
--- a/src/aeroalpes/modulos/vuelos/infraestructura/dto.py
+++ b/src/aeroalpes/modulos/vuelos/infraestructura/dto.py
@@ -39,7 +39,9 @@ class Itinerario(db.Model):
     fecha_salida = db.Column(db.DateTime, nullable=False, primary_key=True)
     fecha_llegada = db.Column(db.DateTime, nullable=False, primary_key=True)
     origen_codigo = db.Column(db.String, nullable=False, primary_key=True)
+    origen_nombre = db.Column(db.String, nullable=False, primary_key=False)
     destino_codigo= db.Column(db.String, nullable=False, primary_key=True)
+    destino_nombre= db.Column(db.String, nullable=False, primary_key=False)
 
 
 class Reserva(db.Model):

--- a/src/aeroalpes/modulos/vuelos/infraestructura/mapeadores.py
+++ b/src/aeroalpes/modulos/vuelos/infraestructura/mapeadores.py
@@ -18,8 +18,8 @@ class MapeadorReserva(Mapeador):
         itin_dict = dict()
         
         for itin in itinerarios_dto:
-            destino = Aeropuerto(codigo=itin.destino_codigo, nombre=None)
-            origen = Aeropuerto(codigo=itin.origen_codigo, nombre=None)
+            destino = Aeropuerto(codigo=itin.destino_codigo, nombre=itin.destino_nombre)
+            origen = Aeropuerto(codigo=itin.origen_codigo, nombre=itin.origen_nombre)
             fecha_salida = itin.fecha_salida
             fecha_llegada = itin.fecha_llegada
 
@@ -45,7 +45,9 @@ class MapeadorReserva(Mapeador):
                 for k, leg in enumerate(seg.legs):
                     itinerario_dto = ItinerarioDTO()
                     itinerario_dto.destino_codigo = leg.destino.codigo
+                    itinerario_dto.destino_nombre = leg.destino.nombre
                     itinerario_dto.origen_codigo = leg.origen.codigo
+                    itinerario_dto.origen_nombre = leg.origen.nombre
                     itinerario_dto.fecha_salida = leg.fecha_salida
                     itinerario_dto.fecha_llegada = leg.fecha_llegada
                     itinerario_dto.leg_orden = k


### PR DESCRIPTION
## Describa el cambio
+ Se agrega nombre de destino y origen en consulta de reserva.

## Razonamiento pedagógico
+ Actualmente el servicio posee endpoint  `/reserva/<id>` que devuelve información de la reserva creada, sin embargo esta respuesta esta incompleta dado que devuelve valor NULO en el atributo que representa el nombre del origien y nombre del destino.

### Lista de chequeo
- [x] Ejecuté el proyecto de forma local o usando Gitpod
- [x] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas