### PR TITLE
Corrección de test unitario

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==22.1.0
 click==8.1.3
 coverage==6.5.0
 Flask==2.2.2
-Flask-SQLAlchemy==3.0.2
+Flask-SQLAlchemy==2.5.1
 flask-swagger==0.2.14
 greenlet==2.0.1
 iniconfig==1.1.1

--- a/src/aeroalpes/api/__init__.py
+++ b/src/aeroalpes/api/__init__.py
@@ -1,5 +1,6 @@
 import os
-from flask import Flask, render_template, request, url_for, redirect, jsonify
+
+from flask import Flask, jsonify, redirect, render_template, request, url_for
 from flask_swagger import swagger
 
 # Identifica el directorio base
@@ -17,8 +18,12 @@ def create_app(configuracion=None):
     # Init la aplicacion de Flask
     app = Flask(__name__, instance_relative_config=True)
 
+    if configuracion is not None and configuracion["TESTING"]:
+        app.config['SQLALCHEMY_DATABASE_URI'] =\
+            'sqlite:///' + configuracion["DATABASE"]
     # Configuracion de BD
-    app.config['SQLALCHEMY_DATABASE_URI'] =\
+    else:
+        app.config['SQLALCHEMY_DATABASE_URI'] =\
             'sqlite:///' + os.path.join(basedir, 'database.db')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
@@ -34,12 +39,7 @@ def create_app(configuracion=None):
         db.create_all()
 
      # Importa Blueprints
-    from . import cliente
-    from . import hoteles
-    from . import pagos
-    from . import precios_dinamicos
-    from . import vehiculos
-    from . import vuelos
+    from . import cliente, hoteles, pagos, precios_dinamicos, vehiculos, vuelos
 
     # Registro de Blueprints
     app.register_blueprint(cliente.bp)

--- a/src/aeroalpes/api/__init__.py
+++ b/src/aeroalpes/api/__init__.py
@@ -21,6 +21,7 @@ def create_app(configuracion=None):
     if configuracion is not None and configuracion["TESTING"]:
         app.config['SQLALCHEMY_DATABASE_URI'] =\
             'sqlite:///' + configuracion["DATABASE"]
+    
     # Configuracion de BD
     else:
         app.config['SQLALCHEMY_DATABASE_URI'] =\


### PR DESCRIPTION
## Describa el cambio
+ El test `test_reservar_vuelo` presente en el archivo **tests/unit/api/test_api.py** no estaba funcionando correctamente, lo que ocurre es que al ejecutar todos los tests, todos pasan, sin embargo, la validación que se realiza en el assert va a permitir que el test pase aún cuando existan errores, en este caso se estaba validando solamente `assert rv is not None`, esta aserción se cumple, sin embargo, si se introduce una aserción como `assert rv.status_code == 200` el test falla ya que existe un error de referencia débil con la base de datos, lo que provoca que al momento de guardar la información en bd se genere un error.

**Ejemplo del error generado**<br>
![image](https://github.com/user-attachments/assets/d283ce54-da1b-4ab2-9c6c-013b3dfe4957)


## Razonamiento pedagógico
+ Uno de los cambios que se realiza en el PR que permite que no se genere el error por weakref es el cambio de versión de Flask-SQLAlchemy, actualmente está en la versión 3.0.2, pero se baja a la versión 2.5.1, con esto el test con la aserción `assert rv.status_code == 200` se ejecuta correctamente, el problema es que si se vuelve a ejecutar el test, va a fallar ya que la información de la base de datos no se está eliminando y en el modelo están algunas llaves primarias que hacen que los campos sean únicos, entonces el error es por violar la restricción de unicidad.

### Solución
+ Cada vez que se ejecutaba un test, se creaba un archivo temporal que no se estaba utilizando, por esto, como primera medida, se ajusta el código para que los archivos temporales se guarden en la ruta `tests/unit/api/` que es donde reside el archivo **test_api.py** el cual es el foco de la solución. Luego se ajusta el archivo __init__.py que se encuentra en `src/aeroalpes/api/__init__.py` con el fin de establecer en la llave **SQLALCHEMY_DATABASE_URI** la configuración de SQLite en caso de ser Test o en caso de ser una ejecución en otro entorno. En **test_api.py** también se crean las variables globales unique_db_path = None y unique_db_fd = 0 para poder controlar que solo se cree un archivo de base de datos, ya que cada ejecución de test estaba generando su propio archivo

**Variables globales y creación de un único archivo de bd** <br>
<img width="633" alt="image" src="https://github.com/user-attachments/assets/f318e8a1-40db-4cad-b8fc-e510a0cea36a" />
<br>
**Identificación de la ruta de SQLite según el ambiente**
<img width="817" alt="image" src="https://github.com/user-attachments/assets/78ae18a4-f34c-434a-98b4-885a9c83b39b" />
<br>
Con lo anterior, ya es posible ejecutar una vez el test para que funcione y solo se genera un archivo de base de datos (finalizado en .db)

+ Lo siguiente fue solucionar los errores de UNIQUE al ejecutar varias veces los mismos tests y tratar de almacenar la misma información, para esto, fue necesario trasladar las instrucciones `os.close(unique_db_fd) y os.unlink(unique_db_path)` en una fixture que se encarga de eliminar el archivo cuando finalicen los tests, como se puede ver a continuación. <br>
<img width="410" alt="image" src="https://github.com/user-attachments/assets/3c84016d-2264-41aa-8fa5-a36ba30778ec" />

<br>
Con lo anterior, los tests ya se pueden ejecutar correctamente y varias veces, como se puede ver a continuación: <br>

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/bcd19561-545f-45ff-9a89-60927db2c99d" />

<br>

Al probar el aplicativo en local, funciona!!
<br>
**Inicio de la aplicación**
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/6767df4a-185c-4d7b-80ab-fc6fb35f3cb8" />

**Creación de Reserva** <br>
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/5deedc53-55f3-483e-827f-60b3a875213a" />
<br>

**Obtención de la reserva** <br>
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/0fdeb3ac-ade4-44ad-ba2e-f74b3c29502f" />
<br>

### Lista de chequeo
- [x] Ejecuté el proyecto de forma local o usando Gitpod
- [x] Corrí todas las pruebas
- [x] Agregué o modifiqué pruebas