### PR TITLE
Ajuste de condicional para retornar la fábrica de repositorio correcta en vuelos

### DIFF
--- a/src/aeroalpes/modulos/vuelos/aplicacion/servicios.py
+++ b/src/aeroalpes/modulos/vuelos/aplicacion/servicios.py
@@ -1,11 +1,14 @@
-from aeroalpes.seedwork.aplicacion.servicios import Servicio
 from aeroalpes.modulos.vuelos.dominio.entidades import Reserva
 from aeroalpes.modulos.vuelos.dominio.fabricas import FabricaVuelos
-from aeroalpes.modulos.vuelos.infraestructura.fabricas import FabricaRepositorio
-from aeroalpes.modulos.vuelos.infraestructura.repositorios import RepositorioReservas
-from .mapeadores import MapeadorReserva
+from aeroalpes.modulos.vuelos.infraestructura.fabricas import \
+    FabricaRepositorio
+from aeroalpes.modulos.vuelos.infraestructura.repositorios import \
+    RepositorioReservas
+from aeroalpes.seedwork.aplicacion.servicios import Servicio
 
 from .dto import ReservaDTO
+from .mapeadores import MapeadorReserva
+
 
 class ServicioReserva(Servicio):
 
@@ -24,12 +27,12 @@ class ServicioReserva(Servicio):
     def crear_reserva(self, reserva_dto: ReservaDTO) -> ReservaDTO:
         reserva: Reserva = self.fabrica_vuelos.crear_objeto(reserva_dto, MapeadorReserva())
 
-        repositorio = self.fabrica_repositorio.crear_objeto(RepositorioReservas.__class__)
+        repositorio = self.fabrica_repositorio.crear_objeto(RepositorioReservas)
         repositorio.agregar(reserva)
 
         return self.fabrica_vuelos.crear_objeto(reserva, MapeadorReserva())
 
     def obtener_reserva_por_id(self, id) -> ReservaDTO:
-        repositorio = self.fabrica_repositorio.crear_objeto(RepositorioReservas.__class__)
+        repositorio = self.fabrica_repositorio.crear_objeto(RepositorioReservas)
         return repositorio.obtener_por_id(id).__dict__
 

--- a/src/aeroalpes/modulos/vuelos/infraestructura/fabricas.py
+++ b/src/aeroalpes/modulos/vuelos/infraestructura/fabricas.py
@@ -20,9 +20,9 @@ from .repositorios import (RepositorioProveedoresSQLite,
 @dataclass
 class FabricaRepositorio(Fabrica):
     def crear_objeto(self, obj: type, mapeador: any = None) -> Repositorio:
-        if obj.__name__ == RepositorioReservas.__name__:
+        if obj == RepositorioReservas:
             return RepositorioReservasSQLite()
-        elif obj.__name__ == RepositorioProveedores.__name__:
+        elif obj == RepositorioProveedores:
             return RepositorioProveedoresSQLite()
         else:
             raise ExcepcionFabrica()

--- a/src/aeroalpes/modulos/vuelos/infraestructura/fabricas.py
+++ b/src/aeroalpes/modulos/vuelos/infraestructura/fabricas.py
@@ -6,18 +6,23 @@ objetos complejos en la capa de infraestructura del dominio de vuelos
 """
 
 from dataclasses import dataclass, field
+
+from aeroalpes.modulos.vuelos.dominio.repositorios import (
+    RepositorioProveedores, RepositorioReservas)
 from aeroalpes.seedwork.dominio.fabricas import Fabrica
 from aeroalpes.seedwork.dominio.repositorios import Repositorio
-from aeroalpes.modulos.vuelos.dominio.repositorios import RepositorioProveedores, RepositorioReservas
-from .repositorios import RepositorioReservasSQLite, RepositorioProveedoresSQLite
+
 from .excepciones import ExcepcionFabrica
+from .repositorios import (RepositorioProveedoresSQLite,
+                           RepositorioReservasSQLite)
+
 
 @dataclass
 class FabricaRepositorio(Fabrica):
     def crear_objeto(self, obj: type, mapeador: any = None) -> Repositorio:
-        if obj == RepositorioReservas.__class__:
+        if obj.__name__ == RepositorioReservas.__name__:
             return RepositorioReservasSQLite()
-        elif obj == RepositorioProveedores.__class__:
+        elif obj.__name__ == RepositorioProveedores.__name__:
             return RepositorioProveedoresSQLite()
         else:
             raise ExcepcionFabrica()


### PR DESCRIPTION
## Describa el cambio
+ En la fábrica de infraestructura de vuelos se está retornando incorrectamente la instancia del repositorio, por esta razón, se realiza una modificación en código que permite retornar la instancia correcta de repositorio al realizar la comparación por nombre de clase, es decir, actualmente se está comparando que si una clase enviada como argumento a la fábrica es igual a otra clase __ class __, se retorna la instancia, pero con __ class __ no funciona como se espera, ya que con __ class __ siempre se obtiene `<class 'type'>`  y el objeto que se recibe como parámetro siempre devuelve `<class 'type'>`, esto hace que se retorne siempre la instancia del primer condicional a pesar de que se envíe una clase diferente. 
## Razonamiento pedagógico
+ Para ilustrar lo antes mencionado, se crea un código que permite evidenciar el problema:
**Código**: <br>
```

from abc import ABC, abstractmethod

class Repositorio():
    ...

class RepositorioReservas(Repositorio):
    ...

class RepositorioProveedores(Repositorio):
    ...


class RepositorioReservasSQLite:
    nombre = "repo 1"
    
class RepositorioProveedoresSQLite:
    nombre = "repo 2"

    
def crear_objeto(obj: type, mapeador: any = None) -> Repositorio:
    if obj.__name__ == RepositorioReservas.__name__:
        return RepositorioReservasSQLite()
    elif obj.__name__ == RepositorioProveedores.__name__:
        return RepositorioProveedoresSQLite()

def crear_objeto_implementacion_actual(obj: type, mapeador: any = None) -> Repositorio:
    if obj == RepositorioReservas.__class__:
        return RepositorioReservasSQLite()
    elif obj == RepositorioProveedores.__class__:
        return RepositorioProveedoresSQLite()
      
print("************* Obteniendo repositorio según el nombre de la clase *************")  
obj = crear_objeto(RepositorioReservas)
print("Para la clase RepositorioReservas el nombre es: ", obj.nombre)
obj = crear_objeto(RepositorioProveedores)
print("Para la clase RepositorioProveedores el nombre es: ", obj.nombre)
print()

print("************* Obteniendo repositorio según implementación actual *************")  
obj = crear_objeto_implementacion_actual(RepositorioReservas.__class__)
print("Para la clase RepositorioReservas el nombre es: ", obj.nombre)
obj = crear_objeto_implementacion_actual(RepositorioProveedores.__class__)
print("Para la clase RepositorioProveedores el nombre es: ", obj.nombre)
```
<br>

[enlace a código](https://www.online-python.com/XoRBvwEapg)

<br>

Las clases `RepositorioReservasSQLite` y `RepositorioProveedoresSQLite` tienen el atributo nombre, al pasar por parámetro la clase `RepositorioReservas` se debería mostrar el nombre repo 1 y si se envía la clase `RepositorioProveedores` se debería mostrar el nombre repo 2, vemos que cuando se realiza con `__ class __` siempre se retorna repo 1 y con `__ name __` se retorna correctamente las instancias de repositorio.

<br>
<img width="623" alt="image" src="https://github.com/user-attachments/assets/cd582d65-816e-4a7b-ac3a-21d2bf8fcf41" />

<br>

### Lista de chequeo
- [x] Ejecuté el proyecto de forma local o usando Gitpod
- [x] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas